### PR TITLE
Improve Challenges pages

### DIFF
--- a/WebApp-OpenIDConnect-DotNet/Views/Account/AccessDenied.cshtml
+++ b/WebApp-OpenIDConnect-DotNet/Views/Account/AccessDenied.cshtml
@@ -3,16 +3,24 @@
     Layout = "~/Views/Shared/_Layout.cshtml";
 }
 
-
-
-<div class="alert alert-danger" role="alert">
-    <h4 class="alert-heading">Not quite there yet!</h4>
-    <p>Your request could not be authorized!</p>
-    <p>Check out the challenges descriptions bellow to understand more.</p>
-    <p>You can also talk to your proctor about any challenge.</p>
+<div class="row">
+    <div class="col-md-12">
+        <br>
+        <div class="alert alert-danger" role="alert">
+            <strong class="alert-heading">Access Denied</strong>
+            - you do not have to acces this page
+        </div>
+    </div>
 </div>
-
-<div class="alert alert-info" role="alert">
-    <h4 class="alert-heading">Review the challenges again</h4>
-    <p>Go to <a class="btn btn-primary" asp-controller="Home" asp-action="Challenges">Challenges</a> and review the requirements to completing your tasks.</p>
+<div class="row">
+    <div class="col-md-6">
+        <h1>Not quite there yet!</h1>
+        <p>This means you have not completed a challenge. To successfully complete a challenge, you must have access to this page.</p>
+        <p>This fix this problem:</p>
+        <ul>
+            <li>Review the <a asp-controller="Home" asp-action="Challenges">challenge</a> requirements to completing your tasks.</li>
+            <li>You can also talk to your proctor about any challenge.</li>
+        </ul>
+        <p><a class="btn btn-primary" asp-controller="Home" asp-action="Challenges">Review Workshop Challenges &rarr;</a></p>
+    </div>
 </div>

--- a/WebApp-OpenIDConnect-DotNet/Views/Home/Api.cshtml
+++ b/WebApp-OpenIDConnect-DotNet/Views/Home/Api.cshtml
@@ -1,23 +1,29 @@
 @{
     ViewData["Title"] = "API";
 }
-<div class="alert alert-success" role="alert">
-    <h4 class="alert-heading">Stretch Challenge!</h4>
-    <p>This is stretch challenge! Consider this challenge only after you completed the other challenges.</p>
-    <p>
-        To complete this challenge you need to deploy a Web API application and configure it.
-        This can be your own API that is protected by your B2C tenant. Or you can use the simple API we provided.
-    </p>
-    <p>Once you deployed and protected Web API by the same B2C tenant, you shall see the results here.</p>
-    <hr>
-    <a class="btn btn-info" href="https://deploy.azure.com/?repository=https://github.com/Dayzure/b2c-preday-webapi-core" role="button">Deploy Simple RESTful API to Azure</a>
+
+<div class="row">
+    <div class="col-md-12">
+        <h1>Challenge #6 (stretch)</h1>
+        <p>This is stretch challenge! Consider this challenge only after you completed <a asp-controller="Home" asp-action="Challenges">challenges 1-5</a>.</p>
+        <p>
+            To complete this challenge you need to deploy a Web API application and configure it.
+            This can be your own API that is protected by your B2C tenant. Or you can use the simple API we provided.
+        </p>
+        <hr>
+
+        <h3>Part 1 - Deploy the App</h3>
+        <p>Once you deployed and protected Web API by the same B2C tenant, you shall see the results below.</p>
+        <p><a class="btn btn-info" href="https://deploy.azure.com/?repository=https://github.com/Dayzure/b2c-preday-webapi-core" role="button">Deploy Simple RESTful API to Azure &rarr;</a></p>
+        <hr>
+
+        <h3>Part 2 - Success Criteria</h3>
+        <h4>API Payload</h4>
+        <p>If the API Payload is empty or showing an error, this means you have not successfully configured it.</p>
+<pre>
+@ViewData["Payload"]
+</pre>
+
+    </div>
 </div>
 
-<h3>API Payload:</h3>
-<div class="alert alert-info" role="alert">
-    @ViewData["Payload"]
-</div>
-
-<div class="alert alert-warning" role="alert">
-    If the API Payload is empty or showing an error, this means you have not successfully configured it.
-</div>

--- a/WebApp-OpenIDConnect-DotNet/Views/Home/Challenges.cshtml
+++ b/WebApp-OpenIDConnect-DotNet/Views/Home/Challenges.cshtml
@@ -4,6 +4,6 @@
     Layout = "~/Views/Shared/_Layout.cshtml";
 }
 
-<h2>Here are the Challenges for today</h2>
+<h1>Workshop Challenges</h1>
 
 @await Html.PartialAsync("~/Views/Shared/_Challenges.cshtml")

--- a/WebApp-OpenIDConnect-DotNet/Views/Shared/_Challenges.cshtml
+++ b/WebApp-OpenIDConnect-DotNet/Views/Shared/_Challenges.cshtml
@@ -84,7 +84,7 @@
     </div>
     <div class="col-md-10">
         <h3>Advanced Custom Policy</h3>
-        <p>To complete this optional challenge you have to extend your custom policy to include the custom attributes already configured in Challenge "Admin"</p>
+        <p>To complete this optional challenge you have to extend your custom policy to include the custom attributes already configured in Challenge #3</p>
 
         <h4>Success Criteria</h4>
         <ul>

--- a/WebApp-OpenIDConnect-DotNet/Views/Shared/_Challenges.cshtml
+++ b/WebApp-OpenIDConnect-DotNet/Views/Shared/_Challenges.cshtml
@@ -1,91 +1,118 @@
-﻿<div class="alert alert-info" role="alert">
-    <h4 class="alert-heading">Challenge <span class="badge badge-success">1</span></h4>
-    <hr />
-    <h4 class="alert-heading">Identity Provider</h4>
-    <p>To go through your challenges you have to add <strong>at least one</strong> external Identity Provider to your B2C tenant.</p>
-    <p>It is advisable to use your newly created Azure AD Enterprise tenant as IdP.</p>
-    <p>It is desirable to add one social IdP which is not Microsoft Account</p>
-    <hr />
-    <h4 class="alert-heading">Success criteria:</h4>
-    <ul>
-        <li>You demonstrate successfull login using at least one local account and one social IdP.</li>
-    </ul>
-</div>
-
-<div class="alert alert-info" role="alert">
-    <h4 class="alert-heading">Challenge <span class="badge badge-success">2</span></h4>
-    <hr />
-    <h4 class="alert-heading">Custom Admin</h4>
-    <p>To complete challenge "Custom Admin" you have to present a custom attribute (claim) with name <strong>extension_CustomAdmin</strong></p>
-    <p>
-        And value one of the:
+﻿<div class="row">
+    <div class="col-md-2">
+        <h3>Challenge #1</h3>
+        <span class="label label-danger">Required</span>
+    </div>
+    <div class="col-md-10">
+        <h3>Add an Identity Provider (IdP)</h3>
+        <p>To go through your challenges you have to add <strong>at least one</strong> external Identity Provider to your B2C tenant.</p>
         <ul>
-            <li>Anton</li>
-            <li>Christer</li>
-            <li>John</li>
+            <li>It is advisable to use your newly created Azure AD Enterprise tenant as IdP</li>
+            <li>It is desirable to add one social IdP which is not Microsoft Account</li>
         </ul>
-    </p>
-    
-    <hr />
-    <h4 class="alert-heading">Success criteria:</h4>
-    <ul>
-        <li>You have to complete this challenge using built-in policy.</li>
-        <li>End users must not be able to write the value of that attribute.</li>
-        <li>You will need to use Graph API to populate attribute value.</li>
-        <li>You must make sure that this value is present regardless of the chosen Identity Provider.</li>
-        <li><a asp-controller="Challenge" asp-action="CustomAdmin" class="btn btn-primary" role="button">This part</a> of the site is successfully loaded</li>
-    </ul>
-</div>
-
-<div class="alert alert-info" role="alert">
-    <h4 class="alert-heading">Challenge <span class="badge badge-success">3</span></h4>
-    <hr />
-    <h4 class="alert-heading">REST Admin</h4>
-    <p>To complete challenge "REST Admin" you have to present a claim obtained from REST service.</p>
-    <p>The name of the claim must be <strong>RestAdmin</strong>. The value will be returned from the REST service</p>
-    <p>
-        Use the following REST endpoint in your custom (IEF) policy:
+        <h4>Success Criteria</h4>
         <ul>
-            <li>https://b2c-preday-rest.azurewebsites.net/api/RestAction?code=cDvT2ioatDtetOjDvU//uBzvD8IR363y3lyDJIWriKw840rWnaPQMg==</li>
+            <li>You demonstrate successfull login using at least one local account and one social IdP.</li>
         </ul>
-    </p>
-    <p>This service is protected by TLS mutual authentication. Contact your proctor to obtain the client certificate needed for authentication to the service.</p>
-    <p>The service expects an <strong>email</strong> input parameter and returns <strong>RestAdmin</strong> claim with required value to unlock your challenge.</p>
-
-    <hr />
-    <h4 class="alert-heading">Success criteria:</h4>
-    <ul>
-        <li>You have a custom policy which uses REST API to call external URL</li>
-        <li><a asp-controller="Challenge" asp-action="RestAdmin" class="btn btn-primary" role="button">This part</a> of the site is successfully loaded</li>
-    </ul>
-
+    </div>
 </div>
 
-<div class="alert alert-warning" role="alert">
-    <h4 class="alert-heading">Challenge <span class="badge badge-success">4</span> (optional)</h4>
-    <hr />
-    <h4 class="alert-heading">Advanced Custom Policy</h4>
-    <p>To complete this optional challenge you have to extend your custom policy to include the custom attributes already configured in Challenge "Admin"</p>
-    <hr />
-    <h4 class="alert-heading">Success criteria:</h4>
-    <ul>
-        <li>You have a custom policy which uses REST API to call external URL</li>
-        <li>You have a custom policy which delcares custom attribute</li>
-        <li><a asp-controller="Challenge" asp-action="SuperAdmin" class="btn btn-primary" role="button">This</a> part of the website is successfully loaded using a single custom policy.</li>
-    </ul>
+<hr>
+
+<div class="row">
+    <div class="col-md-2">
+        <h3>Challenge #2</h3>
+        <span class="label label-danger">Required</span>
+    </div>
+    <div class="col-md-10">
+        <h3>Add Custom Attribute</h3>
+        <p>To complete challenge "Custom Admin" you have to present a custom attribute (claim) with name <strong>extension_CustomAdmin</strong></p>
+        <p>
+            And value one of the:
+            <ul>
+                <li>Anton</li>
+                <li>Christer</li>
+                <li>John</li>
+            </ul>
+        </p>
+
+        <h4>Success Criteria</h4>
+        <ul>
+            <li>You have to complete this challenge using built-in policy</li>
+            <li>End users must not be able to write the value of that attribute</li>
+            <li>You will need to use Graph API to populate attribute value</li>
+            <li>You must make sure that this value is present regardless of the chosen Identity Provider</li>
+            <li>The <strong><a asp-controller="Challenge" asp-action="CustomAdmin">Custom Admin page</a></strong> successfully loads.</li>
+        </ul>
+    </div>
 </div>
 
-<div class="alert alert-warning" role="alert">
-    <h4 class="alert-heading">Challenge <span class="badge badge-success">5</span> (stretch)</h4>
-    <hr />
-    <h4 class="alert-heading">Web API</h4>
-    <p>For this challenge you will need to:</p>
-    <ul>
-        <li>Deploy an Web API</li>
-        <li>Protect that Web API using your B2C Tenant</li>
-        <li>Grant access to the Web API for your current Web Application</li>
-        <li>Configure your current Web Application with the API's scopes and URL</li>
-    </ul>
-    <hr>
-    <p class="mb-0">More information and success criteria are located under <a asp-area="" asp-controller="Home" asp-action="Api">API</a></p>
+<hr>
+
+<div class="row">
+    <div class="col-md-2">
+        <h3>Challenge #3</h3>
+        <span class="label label-danger">Required</span>
+    </div>
+    <div class="col-md-10">
+        <h3>REST Admin</h3>
+        <p>To complete challenge "REST Admin" you have to present a claim obtained from REST service.</p>
+        <ul>
+            <li>The name of the claim must be <code>RestAdmin</code>. The value will be returned from the REST service</li>
+            <li>
+                <p>Use the following REST endpoint in your custom (IEF) policy:<br>
+                <pre><code>https://b2c-preday-rest.azurewebsites.net/api/RestAction?code=cDvT2ioatDtetOjDvU//uBzvD8IR363y3lyDJIWriKw840rWnaPQMg==</code></pre></p>
+                <p>This service is protected by TLS mutual authentication. Contact your proctor to obtain the client certificate needed for authentication to the service.</p>
+            </li>
+            <li>The service expects an <code>email</code> input parameter and returns <code>RestAdmin</code> claim with required value to unlock your challenge</li>
+        </ul>
+
+        <h4>Success Criteria</h4>
+        <ol>
+            <li>You have a custom policy which uses REST API to call external URL</li>
+            <li>The <strong><a asp-controller="Challenge" asp-action="RestAdmin">REST Admin page</a></strong> successfully loads.</li>
+        </ol>
+    </div>
+</div>
+
+<hr>
+
+<div class="row">
+    <div class="col-md-2">
+        <h3>Challenge #4</h3>
+        <span class="label label-warning">Optional</span>
+    </div>
+    <div class="col-md-10">
+        <h3>Advanced Custom Policy</h3>
+        <p>To complete this optional challenge you have to extend your custom policy to include the custom attributes already configured in Challenge "Admin"</p>
+
+        <h4>Success Criteria</h4>
+        <ul>
+            <li>You have a custom policy which uses REST API to call external URL</li>
+            <li>You have a custom policy which delcares custom attribute</li>
+            <li>The <strong><a asp-controller="Challenge" asp-action="CustomAdmin">Custom Admin page</a></strong> and the <strong><a asp-controller="Challenge" asp-action="RestAdmin">REST Admin page</a></strong>
+                of the website are both accessible using single custom policy</li>
+        </ul>
+    </div>
+</div>
+
+<hr>
+
+<div class="row">
+    <div class="col-md-2">
+        <h3>Challenge #5</h3>
+        <span class="label label-warning">Stretch</span>
+    </div>
+    <div class="col-md-10">
+        <h3>Protect Web API</h3>
+        <p>For this challenge you will need to:</p>
+        <ul>
+            <li>Deploy an Web API</li>
+            <li>Protect that Web API using your B2C Tenant</li>
+            <li>Grant access to the Web API for your current Web Application</li>
+            <li>Configure your current Web Application with the API's scopes and URL</li>
+        </ul>
+
+        <p><a class="btn btn-default" asp-controller="Home" asp-action="Api">More information on API challenge page &rarr;</a></p>
+    </div>
 </div>

--- a/WebApp-OpenIDConnect-DotNet/Views/Shared/_Challenges.cshtml
+++ b/WebApp-OpenIDConnect-DotNet/Views/Shared/_Challenges.cshtml
@@ -1,9 +1,9 @@
 ﻿<div class="row">
-    <div class="col-md-2">
+    <div class="col-md-3">
         <h3>Challenge #1</h3>
         <span class="label label-danger">Required</span>
     </div>
-    <div class="col-md-10">
+    <div class="col-md-9">
         <h3>Add an Identity Provider (IdP)</h3>
         <p>To go through your challenges you have to add <strong>at least one</strong> external Identity Provider to your B2C tenant.</p>
         <ul>
@@ -20,11 +20,11 @@
 <hr>
 
 <div class="row">
-    <div class="col-md-2">
+    <div class="col-md-3">
         <h3>Challenge #2</h3>
         <span class="label label-danger">Required</span>
     </div>
-    <div class="col-md-10">
+    <div class="col-md-9">
         <h3>Add Custom Attribute</h3>
         <p>To complete challenge #2 you have to present a custom attribute (claim) with name <code>extension_CustomAdmin</code></p>
         <p>
@@ -50,11 +50,11 @@
 <hr>
 
 <div class="row">
-    <div class="col-md-2">
+    <div class="col-md-3">
         <h3>Challenge #3</h3>
         <span class="label label-danger">Required</span>
     </div>
-    <div class="col-md-10">
+    <div class="col-md-9">
         <h3>REST Admin</h3>
         <p>To complete challenge #3 you have to present a claim obtained from REST service.</p>
         <ul>
@@ -78,11 +78,11 @@
 <hr>
 
 <div class="row">
-    <div class="col-md-2">
+    <div class="col-md-3">
         <h3>Challenge #4</h3>
         <span class="label label-warning">Optional</span>
     </div>
-    <div class="col-md-10">
+    <div class="col-md-9">
         <h3>Advanced Custom Policy</h3>
         <p>To complete this optional challenge you have to extend your custom policy to include the custom attributes already configured in Challenge #3</p>
 
@@ -99,11 +99,11 @@
 <hr>
 
 <div class="row">
-    <div class="col-md-2">
+    <div class="col-md-3">
         <h3>Challenge #5</h3>
         <span class="label label-warning">Stretch</span>
     </div>
-    <div class="col-md-10">
+    <div class="col-md-9">
         <h3>Protect Web API</h3>
         <p>For this challenge you will need to:</p>
         <ul>

--- a/WebApp-OpenIDConnect-DotNet/Views/Shared/_Challenges.cshtml
+++ b/WebApp-OpenIDConnect-DotNet/Views/Shared/_Challenges.cshtml
@@ -26,7 +26,7 @@
     </div>
     <div class="col-md-10">
         <h3>Add Custom Attribute</h3>
-        <p>To complete challenge "Custom Admin" you have to present a custom attribute (claim) with name <strong>extension_CustomAdmin</strong></p>
+        <p>To complete challenge #2 you have to present a custom attribute (claim) with name <code>extension_CustomAdmin</code></p>
         <p>
             And value one of the:
             <ul>
@@ -56,7 +56,7 @@
     </div>
     <div class="col-md-10">
         <h3>REST Admin</h3>
-        <p>To complete challenge "REST Admin" you have to present a claim obtained from REST service.</p>
+        <p>To complete challenge #3 you have to present a claim obtained from REST service.</p>
         <ul>
             <li>The name of the claim must be <code>RestAdmin</code>. The value will be returned from the REST service</li>
             <li>

--- a/WebApp-OpenIDConnect-DotNet/Views/Shared/_Layout.cshtml
+++ b/WebApp-OpenIDConnect-DotNet/Views/Shared/_Layout.cshtml
@@ -37,10 +37,10 @@
                         <ul class="dropdown-menu">
                             <li><a class="dropdown-item" asp-area="" asp-controller="Home" asp-action="Challenges">List of Challenges</a></li>
                             <li role="separator" class="divider"></li>
-                            <li><a asp-area="" asp-controller="Challenge" asp-action="CustomAdmin"><span class="badge badge-light">1</span> Custom Admin</a></li>
-                            <li><a asp-area="" asp-controller="Challenge" asp-action="RestAdmin"><span class="badge badge-light">2</span> REST Actuin</a></li>
-                            <li><a asp-area="" asp-controller="Challenge" asp-action="SuperAdmin"><span class="badge badge-light">3</span> SuperAdmin</a></li>
-                            <li><a asp-area="" asp-controller="Home" asp-action="Api"><span class="badge badge-light">4</span> Web API</a></li>
+                            <li><a asp-area="" asp-controller="Challenge" asp-action="CustomAdmin">1 - Custom Admin</a></li>
+                            <li><a asp-area="" asp-controller="Challenge" asp-action="RestAdmin">2 - REST Actuin</a></li>
+                            <li><a asp-area="" asp-controller="Challenge" asp-action="SuperAdmin">3 - SuperAdmin</a></li>
+                            <li><a asp-area="" asp-controller="Home" asp-action="Api">4 - Web API</a></li>
                         </ul>
                     </li>
                 </ul>


### PR DESCRIPTION
To improve the UX, following changes were made:

- badges were removed for numbers
- challenges are now referred to by number, e.g. "#3" instead of by cryptic name "REST Admin"
- layout changes to clear distinct sections
- some text changes to make tasks or headlines more clear
- alert styling removed and used only as needed

@astaykov - this PR will/may introduce issues:

- the "SuperAdmin" breaks for my and doesn't work, but that's probably because I am running an older code base?
- the numbering in challenges need to be adjusted, because I used 1-6 and the latest changes have 1-4

## Challenges List 

### Before

![Challenges (Before)](https://user-images.githubusercontent.com/1269507/72599732-9037ec00-3912-11ea-8aaa-8e41e22759bc.png)

### After

![Challenges - Challenges (after)](https://user-images.githubusercontent.com/1269507/72599808-afcf1480-3912-11ea-9572-fa46d34891db.png)

## Challenge No. 6

![API - Challenges No 6](https://user-images.githubusercontent.com/1269507/72599961-ff154500-3912-11ea-8041-5fef412574cb.png)

## Access Denied (Challenge incomplete)

### Before

![AccessDenied - Challenges (before)](https://user-images.githubusercontent.com/1269507/72599728-9037ec00-3912-11ea-8ab0-08022dd338a0.png)

### After

![AccessDenied - Challenges (after)](https://user-images.githubusercontent.com/1269507/72599731-9037ec00-3912-11ea-83e0-7f5648754153.png)