### PR TITLE
If you have an incorrect Reply URI (for example use http instead of h…

### DIFF
--- a/WebApp-OpenIDConnect-DotNet/Controllers/HomeController.cs
+++ b/WebApp-OpenIDConnect-DotNet/Controllers/HomeController.cs
@@ -107,8 +107,8 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
             ViewBag.Message = message;
             var exceptionHandlerPathFeature =
                 HttpContext.Features.Get<IExceptionHandlerPathFeature>();
-            ViewBag.Message += exceptionHandlerPathFeature.Error.Message;
-            ViewBag.StackTrace = exceptionHandlerPathFeature.Error.StackTrace;
+            ViewBag.Message += exceptionHandlerPathFeature?.Error?.Message ?? "";
+            ViewBag.StackTrace = exceptionHandlerPathFeature?.Error?.StackTrace ?? "Not Available";
             return View();
         }
     }


### PR DESCRIPTION
…ttps) you can get a NULL ref exception trying to get the Error from the ExceptionHandlerPathFeature